### PR TITLE
Decouple events point counts

### DIFF
--- a/anchorage_cfg.yaml
+++ b/anchorage_cfg.yaml
@@ -2,8 +2,10 @@ min_required_positions: 200
 stationary_period_min_duration_minutes: 720
 stationary_period_max_distance_km: 0.5 
 min_unique_vessels_for_anchorage: 20
+min_port_events_positions: 2
 anchorage_entry_distance_km: 3.0 
 anchorage_exit_distance_km: 4.0 
 stopped_begin_speed_knots: 0.2
 stopped_end_speed_knots: 0.5
 blacklisted_mmsis: [0, 12345]
+

--- a/pipe_anchorages/port_events_pipeline.py
+++ b/pipe_anchorages/port_events_pipeline.py
@@ -59,7 +59,7 @@ def run(options):
     tagged_records = (sources
         | beam.Flatten()
         | cmn.CreateVesselRecords(config['blacklisted_mmsis'], destination=None)
-        | cmn.CreateTaggedRecords(config['min_required_positions'])
+        | cmn.CreateTaggedRecords(config['min_port_events_positions'])
         )
 
     anchorages = (p


### PR DESCRIPTION

* Added a separate point cutoff for port visits. Now we look at a vessel if it has at least *2*
   AIS messages as opposed to *200* that was required before. 

Without this change, the daily port_events in the pipeline will probably miss a lot of events.