### PR TITLE
Use Vessel ID for Port Events and Port Visits

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,8 @@ RUN mkdir -p /opt/project
 WORKDIR /opt/project
 
 # Install and update pip
-RUN pip install -U pip
+# Pin the version because pip>=10.0 does not support the --download flag  which is required for dataflow
+RUN pip install -U --ignore-installed pip==9.0.3
 
 # Download and install google cloud. See the dockerfile at
 # https://hub.docker.com/r/google/cloud-sdk/~/dockerfile/

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,7 +19,7 @@ RUN  \
   apt-get -qqy update && \
   apt-get install -qqy $CLOUD_SDK_APT_DEPS && \
   pip install -U $CLOUD_SDK_PIP_DEPS && \
-  export CLOUD_SDK_VERSION="184.0.0" && \
+  export CLOUD_SDK_VERSION="198.0.0" && \
   export CLOUD_SDK_REPO="cloud-sdk-$(lsb_release -c -s)" && \
   echo "deb https://packages.cloud.google.com/apt $CLOUD_SDK_REPO main" > /etc/apt/sources.list.d/google-cloud-sdk.list && \
   curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | apt-key add - && \

--- a/airflow/pipe_anchorages_dag.py
+++ b/airflow/pipe_anchorages_dag.py
@@ -24,7 +24,8 @@ def table_sensor(dataset_id, table_id, date):
         poke_interval=10,   # check every 10 seconds for a minute
         timeout=60,
         retries=24*7,       # retry once per hour for a week
-        retry_delay=timedelta(minutes=60)
+        retry_delay=timedelta(minutes=60),
+        retry_exponential_backoff=False
     )
 
 

--- a/pipe_anchorages/port_events_pipeline.py
+++ b/pipe_anchorages/port_events_pipeline.py
@@ -19,7 +19,7 @@ from .options.port_events_options import PortEventsOptions
 
 def create_queries(args):
     template = """
-    SELECT STRING(ssvid) as mmsi, lat, lon, timestamp, speed FROM   
+    SELECT vessel_id as mmsi, lat, lon, timestamp, speed FROM   
       TABLE_DATE_RANGE([world-fishing-827:{table}], 
                         TIMESTAMP('{start:%Y-%m-%d}'), TIMESTAMP('{end:%Y-%m-%d}')) 
     """
@@ -58,7 +58,7 @@ def run(options):
 
     tagged_records = (sources
         | beam.Flatten()
-        | cmn.CreateVesselRecords(config['blacklisted_mmsis'], destination=None)
+        | cmn.CreateVesselRecords([], destination=None)
         | cmn.CreateTaggedRecords(config['min_required_positions'])
         )
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-https://codeload.github.com/GlobalFishingWatch/pipe-tools/tar.gz/v0.1.5#egg=pipe-tools-0.1.5
+https://codeload.github.com/GlobalFishingWatch/pipe-tools/tar.gz/v0.1.6#egg=pipe-tools-0.1.6

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ DEPENDENCIES = [
     'pyyaml',
     'unidecode',
     'numpy',
-    "pipe-tools==0.1.5",
+    "pipe-tools==0.1.6",
     "jinja2-cli",
 ]
 

--- a/test/test_event_queries.py
+++ b/test/test_event_queries.py
@@ -10,7 +10,7 @@ class DummyOptions(object):
 def test_create_queries_1():
     args = DummyOptions("2016-01-01", "2016-01-01")
     assert list(create_queries(args)) == ["""
-    SELECT STRING(ssvid) as mmsi, lat, lon, timestamp, speed FROM   
+    SELECT vessel_id as mmsi, lat, lon, timestamp, speed FROM   
       TABLE_DATE_RANGE([world-fishing-827:SOURCE_TABLE], 
                         TIMESTAMP('2015-12-31'), TIMESTAMP('2016-01-01')) 
     """]
@@ -20,12 +20,12 @@ def test_create_queries_2():
     # print list(create_queries(args))[0]
     # print list(create_queries(args))[1]
     assert list(create_queries(args)) == ["""
-    SELECT STRING(ssvid) as mmsi, lat, lon, timestamp, speed FROM   
+    SELECT vessel_id as mmsi, lat, lon, timestamp, speed FROM   
       TABLE_DATE_RANGE([world-fishing-827:SOURCE_TABLE], 
                         TIMESTAMP('2012-04-30'), TIMESTAMP('2015-01-24')) 
     """, 
     """
-    SELECT STRING(ssvid) as mmsi, lat, lon, timestamp, speed FROM   
+    SELECT vessel_id as mmsi, lat, lon, timestamp, speed FROM   
       TABLE_DATE_RANGE([world-fishing-827:SOURCE_TABLE], 
                         TIMESTAMP('2015-01-25'), TIMESTAMP('2017-05-15')) 
     """


### PR DESCRIPTION
Fixes #29 

- use vessel_id
- update pipe-tools to v0.1.6
- update gcloud sdk to 198.0.0
- pin pip version to 9.0.3

Generated one day of events and visits and the output looked good on visual inspection.

