### PR TITLE
Release v0.2.0 

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,15 @@
 Changes
 =======
 
+0.2.0  2018-05-14
+-----------------
+
+* [`#31`](https://github.com/GlobalFishingWatch/anchorages_pipeline/pull/31)
+  Use Vessel ID for Port Events and Port Visits
+* [`#32`](https://github.com/GlobalFishingWatch/anchorages_pipeline/pull/32)
+  - Publish standardized port in/out events
+  - update to pipe-tools v0.1.6  
+  
 0.1.23
 ------
 

--- a/pipe_anchorages/__init__.py
+++ b/pipe_anchorages/__init__.py
@@ -3,7 +3,7 @@ Tools for parsing and normalizing AIS from Orbcomm using dataflow
 """
 
 
-__version__ = '0.1.23'
+__version__ = '0.2.0'
 __author__ = 'Global Fishing Watch'
 __email__ = 'info@globalfishingwatch.org'
 __source__ = 'https://github.com/GlobalFishingWatch/anchorages_pipeline'


### PR DESCRIPTION
Closes #33 

### Changes
#31 Use Vessel ID for Port Events and Port Visits
#32 Publish standardized port in/out events
  update to pipe-tools v0.1.6