### PR TITLE
Support yearly mode in the anchorages pipeline

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,27 +1,36 @@
-Changes
-=======
+# Changelog
 
-0.3.1 - 2018-11-15
-------------------
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a
+Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to
+[Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+### Added
+
+* [GlobalFishingWatch/GFW-Tasks#987](https://github.com/GlobalFishingWatch/GFW-Tasks/issues/987)
+  * Add yearly mode dags.
+* Add parameters for dataflow max_workers and disk_size_gb  
+
+## 0.3.1 - 2018-11-15
 
 * [#39](https://github.com/GlobalFishingWatch/anchorages_pipeline/pull/39)
   * Ensure the creation of empty tables when the dataflow process does not generate content.
   * Updates the operator call to support interval dates.
 
-0.3.0 - 2018-09-07
-------------------
+## 0.3.0 - 2018-09-07
 
 * [#37](https://github.com/GlobalFishingWatch/anchorages_pipeline/pull/37)
   * Removes the publication of events from this pipeline, which will be handled on [pipe-events](https://github.com/globalfishingwatch/pipe-events). See [pipe-events#7](https://github.com/GlobalFishingWatch/pipe-events/pull/7).
 
-0.2.1 2018-09-03
------------------
+## 0.2.1 2018-09-03
 
 * [#36](https://github.com/GlobalFishingWatch/anchorages_pipeline/pull/36)
   * Bump version of pipe-tools to 0.1.7
 
-0.2.0  2018-05-14
------------------
+## 0.2.0  2018-05-14
 
 * [#31](https://github.com/GlobalFishingWatch/anchorages_pipeline/pull/31)
   * Use Vessel ID for Port Events and Port Visits
@@ -29,40 +38,34 @@ Changes
   * Publish standardized port in/out events
   * Update to pipe-tools v0.1.6  
 
-0.1.23
-------
+## 0.1.23
 
 * [#26](https://github.com/GlobalFishingWatch/anchorages_pipeline/pull/26)
   * Re-arrange airflow dags to make them importable into pipe_reference
 
-0.1.22
-------
+## 0.1.22
 
 * [#19](https://github.com/GlobalFishingWatch/anchorages_pipeline/pull/19)
   * Update Dag parameters to conform to new pipeline (copied form pipe-segment).
 
-0.1.0
------
+## 0.1.0
 
 * [#9](https://github.com/GlobalFishingWatch/anchorages_pipeline/pull/9)
   * Reorganize port lists so that it is easier to add new lists.
   * Add `label_source` field.
   * Reduce job file size.
 
-0.0.4
------
+## 0.0.4
 
 * [#7](https://github.com/GlobalFishingWatch/anchorages_pipeline/pull/7)
   * Update name override file for Curacao anchorages
 
-0.0.3
------
+## 0.0.3
 
 * [#6](https://github.com/GlobalFishingWatch/anchorages_pipeline/pull/6)
   * Update name override file following top anchorages review.
 
-0.0.2
------
+## 0.0.2
 
 * [#5](https://github.com/GlobalFishingWatch/anchorages_pipeline/pull/5)
   * Normalize names using unidecode and upper.
@@ -70,8 +73,7 @@ Changes
 * [#4](https://github.com/GlobalFishingWatch/anchorages_pipeline/pull/4)
   * Dockerize so code can be run through docker.
 
-0.0.1
------
+## 0.0.1
 
 * [#3](https://github.com/GlobalFishingWatch/anchorages_pipeline/pull/3)
   * Setup framework for tracking versions and changes.

--- a/airflow/pipe_anchorages_dag.py
+++ b/airflow/pipe_anchorages_dag.py
@@ -213,5 +213,5 @@ port_events_yearly_dag = build_port_events_dag('port_events_yearly', '@yearly')
 
 port_visits_daily_dag = build_port_visits_dag('port_visits_daily', '@daily')
 port_visits_monthly_dag = build_port_visits_dag('port_visits_monthly', '@monthly')
-port_visits_yearlys_dag = build_port_visits_dag('port_yearly_monthly', '@yearly')
+port_visits_yearlys_dag = build_port_visits_dag('port_visits_yearly', '@yearly')
 

--- a/airflow/pipe_anchorages_dag.py
+++ b/airflow/pipe_anchorages_dag.py
@@ -82,8 +82,8 @@ def build_port_events_dag(dag_id, schedule_interval='@daily', extra_default_args
                 output_table='{pipeline_dataset}.{port_events_table}'.format(**config),
                 temp_location='gs://{temp_bucket}/dataflow_temp'.format(**config),
                 staging_location='gs://{temp_bucket}/dataflow_staging'.format(**config),
-                max_num_workers="100",
-                disk_size_gb="50",
+                max_num_workers='{dataflow_max_num_workers}'.format(**config),
+                disk_size_gb='{dataflow_disk_size_gb}'.format(**config),
                 requirements_file='./requirements.txt',
                 setup_file='./setup.py'
             )
@@ -165,8 +165,8 @@ def build_port_visits_dag(dag_id, schedule_interval='@daily', extra_default_args
                 output_table='{pipeline_dataset}.{port_visits_table}'.format(**config),
                 temp_location='gs://{temp_bucket}/dataflow_temp'.format(**config),
                 staging_location='gs://{temp_bucket}/dataflow_staging'.format(**config),
-                max_num_workers="100",
-                disk_size_gb="50",
+                max_num_workers='{dataflow_max_num_workers}'.format(**config),
+                disk_size_gb='{dataflow_disk_size_gb}'.format(**config),
                 requirements_file='./requirements.txt',
                 setup_file='./setup.py'
             )
@@ -209,6 +209,9 @@ def build_port_visits_dag(dag_id, schedule_interval='@daily', extra_default_args
 
 port_events_daily_dag = build_port_events_dag('port_events_daily', '@daily')
 port_events_monthly_dag = build_port_events_dag('port_events_monthly', '@monthly')
+port_events_yearly_dag = build_port_events_dag('port_events_yearly', '@yearly')
 
 port_visits_daily_dag = build_port_visits_dag('port_visits_daily', '@daily')
 port_visits_monthly_dag = build_port_visits_dag('port_visits_monthly', '@monthly')
+port_visits_yearlys_dag = build_port_visits_dag('port_yearly_monthly', '@yearly')
+

--- a/airflow/post_install.sh
+++ b/airflow/post_install.sh
@@ -14,7 +14,7 @@ python $AIRFLOW_HOME/utils/set_default_variables.py \
     pipeline_bucket="{{ var.value.PIPELINE_BUCKET }}" \
     pipeline_dataset="{{ var.value.PIPELINE_DATASET }}" \
     port_visits_start_padding=365 \
-    anchorage_table="gfw_research.named_anchorages_v20180803_13b" \
+    anchorage_table="gfw_research.named_anchorages_v20190307" \
     source_dataset="{{ var.value.PIPELINE_DATASET }}" \
     source_table="position_messages_" \
     port_events_table="port_events_" \

--- a/airflow/post_install.sh
+++ b/airflow/post_install.sh
@@ -14,11 +14,13 @@ python $AIRFLOW_HOME/utils/set_default_variables.py \
     pipeline_bucket="{{ var.value.PIPELINE_BUCKET }}" \
     pipeline_dataset="{{ var.value.PIPELINE_DATASET }}" \
     port_visits_start_padding=365 \
-    anchorage_table=gfw_raw.anchorage_naming_20171026 \
+    anchorage_table="gfw_research.named_anchorages_v20180803_13b" \
     source_dataset="{{ var.value.PIPELINE_DATASET }}" \
     source_table="position_messages_" \
     port_events_table="port_events_" \
-    port_visits_table="port_visits_"
+    port_visits_table="port_visits_" \
+    dataflow_max_num_workers="100" \
+    dataflow_disk_size_gb="50"
 
 
 echo "Installation Complete"


### PR DESCRIPTION
Closes https://github.com/GlobalFishingWatch/GFW-Tasks/issues/987

* Add yearly dags. 
* Added parameters for dataflow `max_workers` and `disk_size_gb`

Other

* Support the new structure of the CHANGELOG file. 

### Testing
I've run both events and visits in the new production run. They can be found here:
`world-fishing-827:pipe_production_v20190225.port_visits_*`
`world-fishing-827:pipe_production_v20190225.port_events_*`

