### PR TITLE
Supports airflow-gfw lib and pipe-tools v2.0.0

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -10,6 +10,9 @@ Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to
 
 ### Added
 
+* [GlobalFishingWatch/GFW-Tasks#991](https://github.com/GlobalFishingWatch/GFW-Tasks/issues/991)
+   * Migrates to use the new [airflow-gfw](https://github.com/GlobalFishingWatch/airflow-gfw) library and use the pipe-tools [v2.0.0](https://github.com/GlobalFishingWatch/pipe-tools/releases/tag/v2.0.0)
+
 ## 0.3.3 - 2019-03-13
 
 * [GlobalFishingWatch/GFW-Tasks#987](https://github.com/GlobalFishingWatch/GFW-Tasks/issues/987)

--- a/airflow/pipe_anchorages_dag.py
+++ b/airflow/pipe_anchorages_dag.py
@@ -6,10 +6,10 @@ from airflow import DAG
 from airflow.contrib.sensors.bigquery_sensor import BigQueryTableSensor
 from airflow.models import Variable
 
-from pipe_tools.airflow.dataflow_operator import DataFlowDirectRunnerOperator
-from pipe_tools.airflow.operators.bigquery_operator import BigQueryCreateEmptyTableOperator
-from pipe_tools.airflow.config import load_config
-from pipe_tools.airflow.config import default_args
+from airflow_ext.gfw.operators.bigquery_operator import BigQueryCreateEmptyTableOperator
+from airflow_ext.gfw.operators.dataflow_operator import DataFlowDirectRunnerOperator
+from airflow_ext.gfw.config import load_config
+from airflow_ext.gfw.config import default_args
 
 
 CONFIG = load_config('pipe_anchorages')

--- a/pipe_anchorages/__init__.py
+++ b/pipe_anchorages/__init__.py
@@ -3,7 +3,7 @@ Pipe for processing anchorages and generating anchorages events.
 """
 
 
-__version__ = '0.3.3'
+__version__ = '1.0.0'
 __author__ = 'Global Fishing Watch'
 __email__ = 'info@globalfishingwatch.org'
 __source__ = 'https://github.com/GlobalFishingWatch/anchorages_pipeline'

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-https://codeload.github.com/GlobalFishingWatch/pipe-tools/tar.gz/v0.2.4#egg=pipe-tools-0.2.4
+https://codeload.github.com/GlobalFishingWatch/pipe-tools/tar.gz/v2.0.0#egg=pipe-tools-2.0.0

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ DEPENDENCIES = [
     'pyyaml',
     'unidecode',
     'numpy',
-    "pipe-tools==0.2.4",
+    "pipe-tools==2.0.0",
     "jinja2-cli",
 ]
 


### PR DESCRIPTION
Updates the code to support [airflow-gfw](https://github.com/GlobalFishingWatch/airflow-gfw) library and also supports the pipe-tools [v2.0.0](https://github.com/GlobalFishingWatch/pipe-tools/releases/tag/v2.0.0)

Related with> https://github.com/GlobalFishingWatch/GFW-Tasks/issues/991