### PR TITLE
Cap Maximum Events at 200, plus bug fixes

### DIFF
--- a/pipe_anchorages/port_visits_pipeline.py
+++ b/pipe_anchorages/port_visits_pipeline.py
@@ -92,7 +92,7 @@ def run(options):
     sink = io.WriteToBigQuery(
         visit_args.output_table,
         schema=build_visit_schema(),
-        write_disposition=io.BigQueryDisposition.WRITE_APPEND,
+        write_disposition=io.BigQueryDisposition.WRITE_TRUNCATE,
         create_disposition=io.BigQueryDisposition.CREATE_IF_NEEDED,
         additional_bq_parameters={
             'timePartitioning': {

--- a/pipe_anchorages/transforms/create_port_visits.py
+++ b/pipe_anchorages/transforms/create_port_visits.py
@@ -87,7 +87,7 @@ class CreatePortVisits(beam.PTransform):
         dlon = evt2.lon - evt1.lon
         # Ensure dlon is in range [-180, 180] 
         # so that we don't have trouble near the dateline
-        dlon = (x + 180) % 360 - 180
+        dlon = (dlon + 180) % 360 - 180
         dist_nm = math.hypot(dlat, scale * dlon) * 60 
         return dist_nm > self.max_interseg_dist_nm
 


### PR DESCRIPTION
The primary purpose of this PR is to fix an issue where in some, rare, cases the number of events per port visit
got very large (~400,000 in one case due to a ferry never leaving port, but generating lots of start/stop events).
The number of events listed in the visit is capped at 200. If there are more than 200, only the first 100 and last 100
are included.

In addition, two bugs I found were fixed.
* Somehow we ended up with write_append instead of write_truncate when writing the new style tables. This was going 
   create more tables at each run.  Replaced with truncate.
* There was a small bug that might manifest when a break between segments cross the dateline. Fixed to keep the delta
   lon in the range [-180, 180).

Also renamed one method: `has_long_interseg_gap` ->  `has_large_interseg_dist` to better reflect that this is checking
the distance (nautical miles) not duration (seconds).