### PR TITLE
Fixes issue on calling jinja2: module 'jinja2.ext' has no attribute 'with_'

### DIFF
--- a/requirements-scheduler.txt
+++ b/requirements-scheduler.txt
@@ -1,4 +1,4 @@
 apache-beam==2.35.0
 pytest==6.2.5
-jinja2-cli==0.7.0
+jinja2-cli==0.8.2
 PyYAML==5.4.1

--- a/requirements-worker.txt
+++ b/requirements-worker.txt
@@ -3,4 +3,4 @@ Fiona==1.8.20
 Shapely==1.7.1
 s2sphere==0.2.5
 Unidecode==1.2.0
-numpy==1.19.5
+


### PR DESCRIPTION
- Updates `jinja2-cli` package from `0.7.0` to `0.8.2` that fixes the error:
```
INFO - Traceback (most recent call last):
INFO -   File "/usr/local/bin/jinja2", line 8, in <module>
INFO -     sys.exit(main())
INFO -   File "/usr/local/lib/python3.7/site-packages/jinja2cli/cli.py", line 424, in main
INFO -     sys.exit(cli(opts, args))
INFO -   File "/usr/local/lib/python3.7/site-packages/jinja2cli/cli.py", line 314, in cli
INFO -     out.write(render(template_path, data, extensions, opts.strict))
INFO -   File "/usr/local/lib/python3.7/site-packages/jinja2cli/cli.py", line 221, in render
INFO -     keep_trailing_newline=True,
INFO -   File "/usr/local/lib/python3.7/site-packages/jinja2/environment.py", line 363, in __init__
INFO -     self.extensions = load_extensions(self, extensions)
INFO -   File "/usr/local/lib/python3.7/site-packages/jinja2/environment.py", line 117, in load_extensions
INFO -     extension = t.cast(t.Type["Extension"], import_string(extension))
INFO -   File "/usr/local/lib/python3.7/site-packages/jinja2/utils.py", line 149, in import_string
INFO -     return getattr(__import__(module, None, None, [obj]), obj)
INFO - AttributeError: module 'jinja2.ext' has no attribute 'with_'
```
- Removes freeze on numpy, and let decide the version coming in the base image of the worker.