### PR TITLE
Pins the numpy==1.20.3

### DIFF
--- a/requirements-worker.txt
+++ b/requirements-worker.txt
@@ -3,4 +3,5 @@ Fiona==1.8.20
 Shapely==1.7.1
 s2sphere==0.2.5
 Unidecode==1.2.0
+numpy==1.20.3
 


### PR DESCRIPTION
- Needed for scheduler image to run test and run beam in direct mode.

Related with> https://globalfishingwatch.atlassian.net/browse/PIPELINE-880