### PR TITLE
Anchorage overrides including 2022 changes and upgrade Google SDK avoid vulnerabilities

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,6 +8,17 @@ Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to
 
 ## [Unreleased]
 
+## v3.3.2 - 2023-07-18
+
+### Added
+
+Adds files via upload. Anchorage overrides including 2022 changes Nate Miller and CianLuck provided in label review
+
+### Changed
+
+* [ENG-521](https://globalfishingwatch.atlassian.net/browse/ENG-521): Changes
+  Updates Google SDK version to avoid vulnerabilities.
+
 ## v3.3.1 - 2022-07-21
 
 ### Changed

--- a/pipe_anchorages/__init__.py
+++ b/pipe_anchorages/__init__.py
@@ -2,12 +2,12 @@
 Pipe for processing anchorages and generating anchorages events. 
 """
 
-__version__ = '3.3.1'
+__version__ = '3.3.3'
 __author__ = 'Global Fishing Watch'
 __email__ = 'info@globalfishingwatch.org'
 __source__ = 'https://github.com/GlobalFishingWatch/anchorages_pipeline'
 __license__ = """
-Copyright 2021 Global Fishing Watch Inc.
+Copyright 2023 Global Fishing Watch Inc.
 Authors:
 
 Tim Hochberg <tim@globalfishingwatch.org>


### PR DESCRIPTION
Changes affect pipe-v2.5.
- Adds files via upload. Anchorage overrides including 2022 changes Nate Miller and CianLuck provided in label review
- Updates Google SDK version to avoid vulnerabilities.
Old image:
![Screenshot from 2023-07-18 15-40-09](https://github.com/GlobalFishingWatch/anchorages_pipeline/assets/432563/e7c6391a-e537-487b-8ee1-3c37b58c1f71)
New image:
![Screenshot from 2023-07-18 16-04-01](https://github.com/GlobalFishingWatch/anchorages_pipeline/assets/432563/6d541411-21e9-43cc-b744-4e93a68e16ad)


Related with> https://globalfishingwatch.atlassian.net/browse/ENG-521