### PR TITLE
Split read transform to avoid getting timeout

### DIFF
--- a/pipe_anchorages/options/port_visits_options.py
+++ b/pipe_anchorages/options/port_visits_options.py
@@ -36,6 +36,10 @@ class PortVisitsOptions(PipelineOptions):
         )
 
         required.add_argument(
+            "--start_date", required=True, help="First date (inclusive) to generate visits"
+        )
+
+        required.add_argument(
             "--end_date", required=True, help="Last date (inclusive) to generate visits"
         )
 


### PR DESCRIPTION
- Adds the `start_date` as required for port-visits options.
- Splits the read tranform to avoid getting timeout in the queries.

Tested with baby_pipeline.
Logs:
```
File "/usr/local/lib/python3.8/socket.py", line 669, in readinto return self._sock.recv_into(b) File "/usr/local/lib/python3.8/ssl.py", line 1241, in recv_into return self.read(nbytes, buffer) File "/usr/local/lib/python3.8/ssl.py", line 1099, in read return self._sslobj.read(len, buffer) socket.timeout: The read operation timed out [while running 'ref_AppliedPTransform_ReadThinnedMessagesJoinedVesselId_0-ReadFromBigQuery-Read-SDFBoundedSourceRead_40/SplitWithSizing-ptransform-38']
```
From:
![Screenshot from 2023-07-20 23-24-30](https://github.com/GlobalFishingWatch/anchorages_pipeline/assets/432563/0f498294-4805-4dd4-b670-e50e03d8479a)
To:
![Screenshot from 2023-07-20 23-26-39](https://github.com/GlobalFishingWatch/anchorages_pipeline/assets/432563/54a89196-88a5-45c6-a4b1-963b84e2f646)


Related with> https://globalfishingwatch.atlassian.net/browse/PIPELINE-1411