### PR TITLE
Pipe-v3: Adds support for AB-2.49

### DIFF
--- a/Dockerfile-worker
+++ b/Dockerfile-worker
@@ -1,4 +1,4 @@
-FROM apache/beam_python3.8_sdk:2.40.0
+FROM apache/beam_python3.8_sdk:2.49.0
 
 # Setup local application dependencies
 COPY ./requirements-worker.txt ./
@@ -7,3 +7,6 @@ RUN apt-get update && \
     export GDAL_VERSION="$(gdal-config --version)"
 
 RUN pip install -r requirements-worker.txt
+
+# Set the entrypoint to the Apache Beam SDK launcher.
+ENTRYPOINT ["/opt/apache/beam/boot"]

--- a/requirements-scheduler.txt
+++ b/requirements-scheduler.txt
@@ -1,5 +1,5 @@
-apache-beam[gcp]==2.40.0
-pytest==6.2.5
+apache-beam[gcp]==2.49.0
+pytest==7.2.2
 jinja2-cli==0.8.2
 pyyaml==5.4.1
 

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import find_packages, setup
 
 setup(
     name="pipe_anchorages",
-    version="4.0.0",
+    version="4.1.0",
     packages=find_packages(exclude=["test*.*", "tests"]),
     package_data={
         "": ["data/port_lists/*.csv", "data/EEZ/*"],


### PR DESCRIPTION
This is for pipe-v3:
- Increments the Apache Beam version from [2.40](https://github.com/apache/beam/releases/tag/v2.40.0) to [2.49](https://github.com/apache/beam/releases/tag/v2.49.0)

Tests are running ok.
Also run the encounters steps, the results were set in the `scratch_matias_ttl_60_days`.

Related with> https://globalfishingwatch.atlassian.net/browse/PIPELINE-1423