### PR TITLE
Fix seg_id in port_visits events

### DIFF
--- a/pipe_anchorages/transforms/create_in_out_events.py
+++ b/pipe_anchorages/transforms/create_in_out_events.py
@@ -118,7 +118,7 @@ class CreateInOutEvents(beam.PTransform, InOutEventsBase):
         )
 
     def _possibly_yield_gap_beg(
-        self, seg_id, last_timestamp, last_state, next_timestamp, active_port
+        self, identity, last_timestamp, last_state, next_timestamp, active_port
     ):
         if next_timestamp - last_timestamp >= self.min_gap:
             if last_state in self.in_port_states:
@@ -128,19 +128,18 @@ class CreateInOutEvents(beam.PTransform, InOutEventsBase):
                     location=cmn.LatLon(None, None), timestamp=evt_timestamp
                 )
                 yield self._build_event(
-                    active_port, rcd, seg_id, self.EVT_GAP_BEG, last_timestamp
+                    active_port, rcd, identity, self.EVT_GAP_BEG, last_timestamp
                 )
 
     def _create_in_out_events(self, grouped_records, anchorage_map):
         seg_id, records = grouped_records
         records = sorted(records, key=lambda x: x.timestamp)
-        identity = records[0].identifier
         rcd = None
         last_state = None
         active_port = None
         last_timestamp = None
         for rcd in records:
-
+            identity = rcd.identifier
             s2id = rcd.location.S2CellId(cmn.VISITS_S2_SCALE).to_token()
             port, dist = self._anchorage_distance(
                 rcd.location, anchorage_map.get(s2id, [])

--- a/pipe_anchorages/transforms/create_port_visits.py
+++ b/pipe_anchorages/transforms/create_port_visits.py
@@ -6,12 +6,10 @@ import math
 
 import apache_beam as beam
 import six
-from pipe_anchorages import common as cmn
 from pipe_anchorages.objects.port_visit import PortVisit
 
 
 class CreatePortVisits(beam.PTransform):
-
     EVENT_TYPES = [
         "PORT_ENTRY",
         # The order of PORT_GAP_XXX is somewhat arbitrary, but it


### PR DESCRIPTION
* Fix seg_id in port_visits events

Also, fix a couple of minor issues I ran across:

* Fix misnamed variable (seg_id -> identity) leftover from previous version when seg_id was the only identity info.
* Remove unused import

In pipe 2.5, this code was run across sets of messages that all shared a single seg_id, however in pipe 3.0 there are multiple seg_ids in the message stream, so we have to update the seg_id for each message.