### PR TITLE
Remove unused technical fields in port_visits

### DIFF
--- a/pipe_anchorages/port_visits_pipeline.py
+++ b/pipe_anchorages/port_visits_pipeline.py
@@ -1,4 +1,4 @@
-from apache_beam import Map, io
+from apache_beam import io
 from apache_beam.options.pipeline_options import StandardOptions, GoogleCloudOptions
 from apache_beam.runners import PipelineState
 
@@ -68,6 +68,8 @@ def event_to_msg(x):
     x = x._asdict()
     x["timestamp"] = _datetime_to_s(x["timestamp"])
     x.pop("vessel_id")
+    x.pop("last_timestamp")
+    x.pop("ssvid")
     return x
 
 
@@ -133,7 +135,7 @@ def run(options):
             end_date=end_date,
         )
         | CreatePortVisits(visit_args.max_inter_seg_dist_nm)
-        | Map(visit_to_msg)
+        | beam.Map(visit_to_msg)
         | sink
     )
 

--- a/pipe_anchorages/schema/port_event.py
+++ b/pipe_anchorages/schema/port_event.py
@@ -5,7 +5,6 @@ def build():
 
     builder = SchemaBuilder()
 
-    builder.add("ssvid", "STRING", description="The ssvid of the vessel involved in the port.")
     builder.add("seg_id", "STRING", description="The segment id belonging to the vessel.")
     builder.add("timestamp", "TIMESTAMP", description="The timestamp when the message was received.")
     builder.add("lat", "FLOAT", description="The latitude included in the message.")
@@ -14,6 +13,5 @@ def build():
     builder.add("vessel_lon", "FLOAT", mode="NULLABLE", description="The longitude of the vessel.")
     builder.add("anchorage_id", "STRING", description="The id of the anchorage.")
     builder.add("event_type", "STRING", description="The event type.")
-    builder.add("last_timestamp", "TIMESTAMP", mode="NULLABLE", description="The last timestamp")
 
     return builder.schema

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import find_packages, setup
 
 setup(
     name="pipe_anchorages",
-    version="4.1.1",
+    version="4.1.2",
     packages=find_packages(exclude=["test*.*", "tests"]),
     package_data={
         "": ["data/port_lists/*.csv", "data/EEZ/*"],

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import find_packages, setup
 
 setup(
     name="pipe_anchorages",
-    version="4.1.0",
+    version="4.1.1",
     packages=find_packages(exclude=["test*.*", "tests"]),
     package_data={
         "": ["data/port_lists/*.csv", "data/EEZ/*"],


### PR DESCRIPTION
- Removes the `event.ssvid` field that belongs to the `port_visit`. The `ssvid` field is also present inside the `port visit`. Deletes repetition of data.
- The `event.last_timestamp` field that belongs to the `port visit` was handling originally the timestamp before the timestamp of an event when points were grouped by `seg_id`, after _smart thinning_ does not make sense.


Test made under the `scratch_matias_ttl_60_days`:
![Screenshot from 2023-09-06 17-26-50](https://github.com/GlobalFishingWatch/anchorages_pipeline/assets/432563/a9d39682-d7bb-49c2-8ea6-5db1c94e6ad1)



Releated with>  https://globalfishingwatch.atlassian.net/browse/PIPELINE-1462