### PR TITLE
Sets description and includes the skill to set a table naming per voyage confidence

### DIFF
--- a/pipe_anchorages/voyages/options.py
+++ b/pipe_anchorages/voyages/options.py
@@ -9,7 +9,11 @@ class VoyagesOptions(PipelineOptions):
         required = parser.add_argument_group('Required')
         required.add_argument('--source_table', required=True,
             help='The port visits table to pull data from')
-        required.add_argument('--output_table', required=True,
+        required.add_argument('--output_table_c2', required=True,
+            help='Output table to write results to.')
+        required.add_argument('--output_table_c3', required=True,
+            help='Output table to write results to.')
+        required.add_argument('--output_table_c4', required=True,
             help='Output table to write results to.')
 
         optional = parser.add_argument_group('Optional')

--- a/pipe_anchorages/voyages/pipeline.py
+++ b/pipe_anchorages/voyages/pipeline.py
@@ -44,6 +44,7 @@ class VoyagesPipeline:
         ):
             result.wait_until_finish()
             if result.state == PipelineState.DONE:
+                self.sink.update_description()
                 self.sink.update_labels()
 
         logging.info("Returning with result.state=%s" % result.state)

--- a/pipe_anchorages/voyages/transforms/sink.py
+++ b/pipe_anchorages/voyages/transforms/sink.py
@@ -138,9 +138,6 @@ Created by pipe-anchorages: {self.ver}
                 "clustering": {
                     "fields": ["trip_start", "ssvid", "vessel_id", "trip_id"]
                 },
-                "destinationTableProperties": {
-                    "description": self.get_description(confidence),
-                },
             },
             write_disposition=beam.io.BigQueryDisposition.WRITE_TRUNCATE,
             create_disposition=beam.io.BigQueryDisposition.CREATE_IF_NEEDED,
@@ -151,6 +148,13 @@ Created by pipe-anchorages: {self.ver}
         dataset_ref = bigquery.DatasetReference(self.cloud.project, dataset_id)
         table_ref = dataset_ref.table(f'{table_name}{confidence}')
         return bqclient.get_table(table_ref)  # API request
+
+    def update_description(self):
+        bqclient = bigquery.Client(project=self.cloud.project)
+        for c in [2,3,4]:
+            table = self._get_table(bqclient, c)
+            table.description = self.get_description(c)
+            bqclient.update_table(table, ["description"])  # API request
 
     def update_labels(self):
         bqclient = bigquery.Client(project=self.cloud.project)

--- a/pipe_anchorages/voyages/transforms/sink.py
+++ b/pipe_anchorages/voyages/transforms/sink.py
@@ -86,7 +86,7 @@ class WriteSink(beam.PTransform):
     }
 
     def __init__(self, options, cloud_options):
-        self.sink_table = options.output_table
+        self.sink_table = {2:options.output_table_c2, 3:options.output_table_c3, 4:options.output_table_c4}
         self.options = options
         self.cloud = cloud_options
         self.ver = get_pipe_ver()
@@ -127,7 +127,7 @@ Created by pipe-anchorages: {self.ver}
 
     def write_sink(self, confidence):
         return beam.io.WriteToBigQuery(
-            f"{self.sink_table}{confidence}",
+            f"{self.sink_table[confidence]}",
             schema=WriteSink.TABLE_SCHEMA,
             additional_bq_parameters={
                 "timePartitioning": {
@@ -144,9 +144,9 @@ Created by pipe-anchorages: {self.ver}
         )
 
     def _get_table(self, bqclient:bigquery.Client, confidence:int):
-        dataset_id, table_name = self.sink_table.split('.')
+        dataset_id, table_name = self.sink_table[confidence].split('.')
         dataset_ref = bigquery.DatasetReference(self.cloud.project, dataset_id)
-        table_ref = dataset_ref.table(f'{table_name}{confidence}')
+        table_ref = dataset_ref.table(table_name)
         return bqclient.get_table(table_ref)  # API request
 
     def update_description(self):


### PR DESCRIPTION
- Lets update a dynamic description to the table using the `google-cloud-bigquery` api.
- Includes the skill to set an specific table naming and dataset per each voyage confidence.

Related with> https://globalfishingwatch.atlassian.net/browse/PIPELINE-1031