### PR TITLE
Fixes the voyages trip_id and vessel_id description column

### DIFF
--- a/pipe_anchorages/voyages/transforms/sink.py
+++ b/pipe_anchorages/voyages/transforms/sink.py
@@ -20,7 +20,7 @@ class WriteSink(beam.PTransform):
               "mode": "NULLABLE",
               "name": "vessel_id",
               "type": "STRING",
-              "description": "The unique vessel id. This table has one row per vessel_id."
+              "description": "The vessel id."
             },
             {
               "mode": "NULLABLE",
@@ -74,7 +74,7 @@ class WriteSink(beam.PTransform):
               "mode": "NULLABLE",
               "name": "trip_id",
               "type": "STRING",
-              "description": "The confidence of the visit where the trip ended."
+              "description": "The unique value for the table. There is a single record for each trip_id."
             },
         ]
     }

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import find_packages, setup
 
 setup(
     name="pipe_anchorages",
-    version="4.2.0",
+    version="4.2.1",
     packages=find_packages(exclude=["test*.*", "tests"]),
     package_data={
         "": ["data/port_lists/*.csv", "data/EEZ/*"],


### PR DESCRIPTION
- Fixes the `vessel_id` and `trip_id` description column for the voyages as it's indicated in the ticket.

Related with> https://globalfishingwatch.atlassian.net/browse/PIPELINE-1571