### PR TITLE
Avoid Generating Extra Gaps

### DIFF
--- a/pipe_anchorages/port_visits_pipeline.py
+++ b/pipe_anchorages/port_visits_pipeline.py
@@ -1,22 +1,23 @@
-from apache_beam import Map, io
-from apache_beam.options.pipeline_options import StandardOptions, GoogleCloudOptions
-from apache_beam.runners import PipelineState
+import datetime
+import logging
 
+import apache_beam as beam
+import pytz
+from apache_beam import Map
+from apache_beam.options.pipeline_options import (GoogleCloudOptions,
+                                                  StandardOptions)
+from apache_beam.runners import PipelineState
 from pipe_anchorages import common as cmn
 from pipe_anchorages.objects.namedtuples import _datetime_to_s
 from pipe_anchorages.options.port_visits_options import PortVisitsOptions
-from pipe_anchorages.records import VesselLocationRecord
 from pipe_anchorages.schema.port_visit import build as build_visit_schema
 from pipe_anchorages.transforms.create_in_out_events import CreateInOutEvents
 from pipe_anchorages.transforms.create_port_visits import CreatePortVisits
-from pipe_anchorages.transforms.create_tagged_anchorages import CreateTaggedAnchorages
+from pipe_anchorages.transforms.create_tagged_anchorages import \
+    CreateTaggedAnchorages
 from pipe_anchorages.transforms.sink import VisitsSink
+from pipe_anchorages.transforms.smart_thin_records import VisitLocationRecord
 from pipe_anchorages.transforms.source import QuerySource
-
-import apache_beam as beam
-import datetime
-import logging
-import pytz
 
 
 def create_queries(args, end_date):
@@ -41,7 +42,12 @@ def create_queries(args, end_date):
     )
 
 
-anchorage_query = lambda table: f"SELECT lat as anchor_lat, lon as anchor_lon, s2id as anchor_id, label FROM `{table}`"
+anchorage_query = (
+    lambda table: f"SELECT lat as anchor_lat, lon as anchor_lon, s2id as anchor_id, label FROM `{table}`"
+)
+
+
+# TODO:
 
 
 def from_msg(x):
@@ -54,7 +60,7 @@ def from_msg(x):
     vessel_id = x.pop("vessel_id")
     ident = (ssvid, vessel_id, seg_id)
     loc = cmn.LatLon(x.pop("lat"), x.pop("lon"))
-    return vessel_id, VesselLocationRecord(identifier=ident, location=loc, **x)
+    return vessel_id, VisitLocationRecord(identifier=ident, location=loc, **x)
 
 
 def event_to_msg(x):
@@ -78,7 +84,6 @@ def drop_new_fields(x):
 
 
 def run(options):
-
     visit_args = options.view_as(PortVisitsOptions)
     cloud_args = options.view_as(GoogleCloudOptions)
 
@@ -94,23 +99,20 @@ def run(options):
 
     anchorages = (
         p
-        | "ReadAnchorages" >> QuerySource(anchorage_query(visit_args.anchorage_table), cloud_args)
+        | "ReadAnchorages"
+        >> QuerySource(anchorage_query(visit_args.anchorage_table), cloud_args)
         | CreateTaggedAnchorages()
     )
 
     queries = create_queries(visit_args, end_date)
 
     sources = [
-        (
-            p | f"ReadThinnedMessagesJoinedVesselId_{i}" >> QuerySource(query, cloud_args)
-        ) for (i, query) in enumerate(queries)
+        (p | f"ReadThinnedMessagesJoinedVesselId_{i}" >> QuerySource(query, cloud_args))
+        for (i, query) in enumerate(queries)
     ]
 
     sink = VisitsSink(
-        visit_args.output_table,
-        build_visit_schema(),
-        visit_args,
-        cloud_args
+        visit_args.output_table, build_visit_schema(), visit_args, cloud_args
     )
 
     (
@@ -154,5 +156,3 @@ def run(options):
 
     logging.info("returning with result.state=%s" % result.state)
     return 0 if result.state in success_states else 1
-
-

--- a/pipe_anchorages/schema/message_schema.py
+++ b/pipe_anchorages/schema/message_schema.py
@@ -26,10 +26,10 @@ message_schema = {
             "type": "FLOAT",
         },
         {
-            "description": "The destination included in the message.",
+            "description": "Could this message could this message be a gap end.",
             "mode": "NULLABLE",
-            "name": "destination",
-            "type": "STRING",
+            "name": "is_possible_gap_end",
+            "type": "BOOL",
         },
     ]
 }

--- a/pipe_anchorages/thin_port_messages_pipeline.py
+++ b/pipe_anchorages/thin_port_messages_pipeline.py
@@ -1,18 +1,16 @@
-import datetime
-import logging
-
-import apache_beam as beam
-from apache_beam.options.pipeline_options import (GoogleCloudOptions,
-                                                  StandardOptions)
+from apache_beam.options.pipeline_options import (GoogleCloudOptions, StandardOptions)
 from apache_beam.runners import PipelineState
+
 from pipe_anchorages import common as cmn
-from pipe_anchorages.options.thin_port_messages_options import \
-    ThinPortMessagesOptions
-from pipe_anchorages.transforms.create_tagged_anchorages import \
-    CreateTaggedAnchorages
+from pipe_anchorages.options.thin_port_messages_options import ThinPortMessagesOptions
+from pipe_anchorages.transforms.create_tagged_anchorages import CreateTaggedAnchorages
 from pipe_anchorages.transforms.sink import MessageSink
 from pipe_anchorages.transforms.smart_thin_records import SmartThinRecords
 from pipe_anchorages.transforms.source import QuerySource
+
+import apache_beam as beam
+import datetime
+import logging
 
 
 def create_queries(args, start_date, end_date):
@@ -46,13 +44,11 @@ def create_queries(args, start_date, end_date):
         start_window = end_window + datetime.timedelta(days=1)
 
 
-anchorage_query = (
-    lambda args: f"SELECT lat as anchor_lat, lon as anchor_lon, "
-    f"s2id as anchor_id, label FROM `{args.anchorage_table}`"
-)
+anchorage_query = lambda args: f"SELECT lat as anchor_lat, lon as anchor_lon, s2id as anchor_id, label FROM `{args.anchorage_table}`"
 
 
 def run(options):
+
     known_args = options.view_as(ThinPortMessagesOptions)
     cloud_options = options.view_as(GoogleCloudOptions)
 
@@ -66,8 +62,9 @@ def run(options):
     queries = create_queries(known_args, start_date, end_date)
 
     sources = [
-        (p | f"Read_{i}" >> QuerySource(query, cloud_options))
-        for (i, query) in enumerate(queries)
+        ( p
+        | f"Read_{i}" >> QuerySource(query, cloud_options)
+        ) for (i, query) in enumerate(queries)
     ]
 
     tagged_records = (
@@ -83,7 +80,11 @@ def run(options):
         | CreateTaggedAnchorages()
     )
 
-    sink = MessageSink(known_args.output_table, known_args, cloud_options)
+    sink = MessageSink(
+        known_args.output_table,
+        known_args,
+        cloud_options
+    )
 
     (
         tagged_records

--- a/pipe_anchorages/transforms/create_in_out_events.py
+++ b/pipe_anchorages/transforms/create_in_out_events.py
@@ -140,7 +140,6 @@ class CreateInOutEvents(beam.PTransform, InOutEventsBase):
         active_port = None
         last_timestamp = None
         for rcd in records:
-
             s2id = rcd.location.S2CellId(cmn.VISITS_S2_SCALE).to_token()
             port, dist = self._anchorage_distance(
                 rcd.location, anchorage_map.get(s2id, [])
@@ -153,6 +152,7 @@ class CreateInOutEvents(beam.PTransform, InOutEventsBase):
             if last_timestamp is not None:
                 if (
                     last_state in self.in_port_states
+                    and rcd.is_possible_gap_end
                     and rcd.timestamp - last_timestamp >= self.min_gap
                 ):
                     yield self._build_event(


### PR DESCRIPTION
This PR attempts to reduce the number of extra gaps being generated by tagging messages during the thinning phase
with `is_possible_gap_end`. Only tagged messages that have this set to true can generate a gap event.

> [!CAUTION]
> This has not been tested. Do not merge without testing!

## Changes

* `message_schema.py`: add `is_possible_gap_end` column. Remove unused `destination` column.
* `smart_thin_records.py`: Convert VesselLocationRecords to VisitLocationRecords on input. These have the added field `is_possible_gap_end`, which is initially set to False. When emitting points due to a gap, set `is_possible_gap_end` to True for the gap end.
* `port_visits_pipeline.py`: load messages as VisitLocationRecord rather the VesselLocationRecord to accommodate `is_possible_gap_end` field.
* `create_in_out_events.py`: Only generate gap events if the end point has `is_possible_gap_end` set.