### PR TITLE
Cache port lookups

### DIFF
--- a/pipe_anchorages/port_visits_pipeline.py
+++ b/pipe_anchorages/port_visits_pipeline.py
@@ -1,22 +1,23 @@
-from apache_beam import Map, io
-from apache_beam.options.pipeline_options import StandardOptions, GoogleCloudOptions
-from apache_beam.runners import PipelineState
+import datetime
+import logging
 
+import apache_beam as beam
+import pytz
+from apache_beam import Map
+from apache_beam.options.pipeline_options import (GoogleCloudOptions,
+                                                  StandardOptions)
+from apache_beam.runners import PipelineState
 from pipe_anchorages import common as cmn
 from pipe_anchorages.objects.namedtuples import _datetime_to_s
 from pipe_anchorages.options.port_visits_options import PortVisitsOptions
-from pipe_anchorages.records import VesselLocationRecord
 from pipe_anchorages.schema.port_visit import build as build_visit_schema
 from pipe_anchorages.transforms.create_in_out_events import CreateInOutEvents
 from pipe_anchorages.transforms.create_port_visits import CreatePortVisits
-from pipe_anchorages.transforms.create_tagged_anchorages import CreateTaggedAnchorages
+from pipe_anchorages.transforms.create_tagged_anchorages import \
+    CreateTaggedAnchorages
 from pipe_anchorages.transforms.sink import VisitsSink
+from pipe_anchorages.transforms.smart_thin_records import VisitLocationRecord
 from pipe_anchorages.transforms.source import QuerySource
-
-import apache_beam as beam
-import datetime
-import logging
-import pytz
 
 
 def create_queries(args, end_date):
@@ -41,7 +42,12 @@ def create_queries(args, end_date):
     )
 
 
-anchorage_query = lambda table: f"SELECT lat as anchor_lat, lon as anchor_lon, s2id as anchor_id, label FROM `{table}`"
+anchorage_query = (
+    lambda table: f"SELECT lat as anchor_lat, lon as anchor_lon, s2id as anchor_id, label FROM `{table}`"
+)
+
+
+# TODO:
 
 
 def from_msg(x):
@@ -54,7 +60,7 @@ def from_msg(x):
     vessel_id = x.pop("vessel_id")
     ident = (ssvid, vessel_id, seg_id)
     loc = cmn.LatLon(x.pop("lat"), x.pop("lon"))
-    return vessel_id, VesselLocationRecord(identifier=ident, location=loc, **x)
+    return vessel_id, VisitLocationRecord(identifier=ident, location=loc, **x)
 
 
 def event_to_msg(x):
@@ -78,7 +84,6 @@ def drop_new_fields(x):
 
 
 def run(options):
-
     visit_args = options.view_as(PortVisitsOptions)
     cloud_args = options.view_as(GoogleCloudOptions)
 
@@ -94,23 +99,20 @@ def run(options):
 
     anchorages = (
         p
-        | "ReadAnchorages" >> QuerySource(anchorage_query(visit_args.anchorage_table), cloud_args)
+        | "ReadAnchorages"
+        >> QuerySource(anchorage_query(visit_args.anchorage_table), cloud_args)
         | CreateTaggedAnchorages()
     )
 
     queries = create_queries(visit_args, end_date)
 
     sources = [
-        (
-            p | f"ReadThinnedMessagesJoinedVesselId_{i}" >> QuerySource(query, cloud_args)
-        ) for (i, query) in enumerate(queries)
+        (p | f"ReadThinnedMessagesJoinedVesselId_{i}" >> QuerySource(query, cloud_args))
+        for (i, query) in enumerate(queries)
     ]
 
     sink = VisitsSink(
-        visit_args.output_table,
-        build_visit_schema(),
-        visit_args,
-        cloud_args
+        visit_args.output_table, build_visit_schema(), visit_args, cloud_args
     )
 
     (
@@ -154,5 +156,3 @@ def run(options):
 
     logging.info("returning with result.state=%s" % result.state)
     return 0 if result.state in success_states else 1
-
-

--- a/pipe_anchorages/port_visits_pipeline.py
+++ b/pipe_anchorages/port_visits_pipeline.py
@@ -1,5 +1,6 @@
 import datetime
 import logging
+import math
 
 import apache_beam as beam
 import pytz
@@ -47,9 +48,6 @@ anchorage_query = (
 )
 
 
-# TODO:
-
-
 def from_msg(x):
     x = x.copy()
     x["timestamp"] = datetime.datetime.utcfromtimestamp(x["timestamp"]).replace(
@@ -60,7 +58,12 @@ def from_msg(x):
     vessel_id = x.pop("vessel_id")
     ident = (ssvid, vessel_id, seg_id)
     loc = cmn.LatLon(x.pop("lat"), x.pop("lon"))
-    return vessel_id, VisitLocationRecord(identifier=ident, location=loc, **x)
+    port_dist = x.pop('port_dist')
+    if port_dist is None:
+        port_dist = math.inf
+    return vessel_id, VisitLocationRecord(
+        identifier=ident, location=loc, port_dist=port_dist, **x
+    )
 
 
 def event_to_msg(x):

--- a/pipe_anchorages/schema/message_schema.py
+++ b/pipe_anchorages/schema/message_schema.py
@@ -26,10 +26,10 @@ message_schema = {
             "type": "FLOAT",
         },
         {
-            "description": "The destination included in the message.",
+            "description": "Could this message could this message be a gap end.",
             "mode": "NULLABLE",
-            "name": "destination",
-            "type": "STRING",
+            "name": "is_possible_gap_end",
+            "type": "BOOL",
         },
     ]
 }

--- a/pipe_anchorages/schema/message_schema.py
+++ b/pipe_anchorages/schema/message_schema.py
@@ -31,5 +31,29 @@ message_schema = {
             "name": "is_possible_gap_end",
             "type": "BOOL",
         },
+        {
+            "description": "If we are near an anchorage, what is it's S2 ID.",
+            "mode": "NULLABLE",
+            "name": "port_s2id",
+            "type": "STRING",
+        },
+        {
+            "description": "If we are near an anchorage, how far away is it.",
+            "mode": "NULLABLE",
+            "name": "port_dist",
+            "type": "FLOAT",
+        },
+        {
+            "description": "If we are near an anchorage, what is its mean longitude.",
+            "mode": "NULLABLE",
+            "name": "port_lon",
+            "type": "FLOAT",
+        },
+        {
+            "description": "If we are near an anchorage, what is its mean latitude.",
+            "mode": "NULLABLE",
+            "name": "port_lat",
+            "type": "FLOAT",
+        },
     ]
 }

--- a/pipe_anchorages/thin_port_messages_pipeline.py
+++ b/pipe_anchorages/thin_port_messages_pipeline.py
@@ -1,18 +1,16 @@
-import datetime
-import logging
-
-import apache_beam as beam
-from apache_beam.options.pipeline_options import (GoogleCloudOptions,
-                                                  StandardOptions)
+from apache_beam.options.pipeline_options import (GoogleCloudOptions, StandardOptions)
 from apache_beam.runners import PipelineState
+
 from pipe_anchorages import common as cmn
-from pipe_anchorages.options.thin_port_messages_options import \
-    ThinPortMessagesOptions
-from pipe_anchorages.transforms.create_tagged_anchorages import \
-    CreateTaggedAnchorages
+from pipe_anchorages.options.thin_port_messages_options import ThinPortMessagesOptions
+from pipe_anchorages.transforms.create_tagged_anchorages import CreateTaggedAnchorages
 from pipe_anchorages.transforms.sink import MessageSink
 from pipe_anchorages.transforms.smart_thin_records import SmartThinRecords
 from pipe_anchorages.transforms.source import QuerySource
+
+import apache_beam as beam
+import datetime
+import logging
 
 
 def create_queries(args, start_date, end_date):
@@ -46,13 +44,11 @@ def create_queries(args, start_date, end_date):
         start_window = end_window + datetime.timedelta(days=1)
 
 
-anchorage_query = (
-    lambda args: f"SELECT lat as anchor_lat, lon as anchor_lon, "
-    f"s2id as anchor_id, label FROM `{args.anchorage_table}`"
-)
+anchorage_query = lambda args: f"SELECT lat as anchor_lat, lon as anchor_lon, s2id as anchor_id, label FROM `{args.anchorage_table}`"
 
 
 def run(options):
+
     known_args = options.view_as(ThinPortMessagesOptions)
     cloud_options = options.view_as(GoogleCloudOptions)
 
@@ -66,8 +62,9 @@ def run(options):
     queries = create_queries(known_args, start_date, end_date)
 
     sources = [
-        (p | f"Read_{i}" >> QuerySource(query, cloud_options))
-        for (i, query) in enumerate(queries)
+        ( p
+        | f"Read_{i}" >> QuerySource(query, cloud_options)
+        ) for (i, query) in enumerate(queries)
     ]
 
     tagged_records = (
@@ -83,7 +80,11 @@ def run(options):
         | CreateTaggedAnchorages()
     )
 
-    sink = MessageSink(known_args.output_table, known_args, cloud_options)
+    sink = MessageSink(
+        known_args.output_table,
+        known_args,
+        cloud_options
+    )
 
     (
         tagged_records

--- a/pipe_anchorages/transforms/create_in_out_events.py
+++ b/pipe_anchorages/transforms/create_in_out_events.py
@@ -42,6 +42,8 @@ class InOutEventsBase:
     }
 
     def _is_in_port(self, state, dist):
+        if dist is None:
+            return False
         if dist <= self.anchorage_entry_dist:
             return True
         elif dist >= self.anchorage_exit_dist:
@@ -99,12 +101,12 @@ class CreateInOutEvents(beam.PTransform, InOutEventsBase):
             days=1
         ), "min gap must be under one day in current implementation"
 
-    def _build_event(self, active_port, rcd, event_type, last_timestamp):
+    def _build_event(self, active_port_rcd, rcd, event_type, last_timestamp):
         ssvid, vessel_id, seg_id = rcd.identifier
         return VisitEvent(
-            anchorage_id=active_port.s2id,
-            lat=active_port.mean_location.lat,
-            lon=active_port.mean_location.lon,
+            anchorage_id=active_port_rcd.port_s2id,
+            lat=active_port_rcd.port_lat,
+            lon=active_port_rcd.port_lon,
             vessel_lat=rcd.location.lat,
             vessel_lon=rcd.location.lon,
             ssvid=ssvid,
@@ -115,7 +117,7 @@ class CreateInOutEvents(beam.PTransform, InOutEventsBase):
             last_timestamp=last_timestamp,
         )
 
-    def _yield_gap_beg(self, gap_end_rcd, last_timestamp, last_state, active_port):
+    def _yield_gap_beg(self, gap_end_rcd, last_timestamp, last_state, active_port_rcd):
         evt_timestamp = last_timestamp + self.min_gap
         assert evt_timestamp <= gap_end_rcd.timestamp
         rcd = PseudoRcd(
@@ -123,23 +125,24 @@ class CreateInOutEvents(beam.PTransform, InOutEventsBase):
             timestamp=evt_timestamp,
             identifier=gap_end_rcd.identifier,
         )
-        yield self._build_event(active_port, rcd, self.EVT_GAP_BEG, last_timestamp)
+        yield self._build_event(active_port_rcd, rcd, self.EVT_GAP_BEG, last_timestamp)
 
-    def _create_in_out_events(self, records, anchorage_map):
+    def _create_in_out_events(self, records):
         records = sorted(records, key=lambda x: x.timestamp)
         ssvid, vessel_id, seg_id = records[0].identifier
-        identity = (ssvid, vessel_id)
+        # identity = (ssvid, vessel_id)
         rcd = None
         last_state = None
-        active_port = None
+        active_port_rcd = None
         last_timestamp = None
         for rcd in records:
-            s2id = rcd.location.S2CellId(cmn.VISITS_S2_SCALE).to_token()
-            port, dist = self._anchorage_distance(
-                rcd.location, anchorage_map.get(s2id, [])
-            )
-            is_in_port = self._is_in_port(last_state, dist)
-            active_port = port if is_in_port else active_port
+            # s2id = rcd.location.S2CellId(cmn.VISITS_S2_SCALE).to_token()
+            # port, dist = self._anchorage_distance(
+            #     rcd.location, anchorage_map.get(s2id, [])
+            # )
+            # s2_id =
+            is_in_port = self._is_in_port(last_state, rcd.port_dist)
+            active_port_rcd = rcd if is_in_port else active_port_rcd
             is_stopped = self._is_stopped(last_state, rcd.speed)
             state = self._compute_state(is_in_port, is_stopped)
 
@@ -150,24 +153,23 @@ class CreateInOutEvents(beam.PTransform, InOutEventsBase):
                     and rcd.timestamp - last_timestamp >= self.min_gap
                 ):
                     yield self._build_event(
-                        active_port, rcd, self.EVT_GAP_END, last_timestamp
+                        active_port_rcd, rcd, self.EVT_GAP_END, last_timestamp
                     )
                     yield from self._yield_gap_beg(
-                        rcd, last_timestamp, last_state, active_port
+                        rcd, last_timestamp, last_state, active_port_rcd
                     )
 
             for event_type in self.transition_map[(last_state, state)]:
-                yield self._build_event(active_port, rcd, event_type, last_timestamp)
+                yield self._build_event(
+                    active_port_rcd, rcd, event_type, last_timestamp
+                )
 
             last_timestamp = rcd.timestamp
             last_state = state
 
-    def create_in_out_events(self, grouped_records, anchorage_map):
+    def create_in_out_events(self, grouped_records):
         identity, records = grouped_records
-        return identity, list(self._create_in_out_events(records, anchorage_map))
+        return identity, list(self._create_in_out_events(records))
 
     def expand(self, grouped_records):
-        anchorage_map = beam.pvalue.AsDict(self.anchorages)
-        return grouped_records | beam.Map(
-            self.create_in_out_events, anchorage_map=anchorage_map
-        )
+        return grouped_records | beam.Map(self.create_in_out_events)

--- a/pipe_anchorages/transforms/create_in_out_events.py
+++ b/pipe_anchorages/transforms/create_in_out_events.py
@@ -130,17 +130,11 @@ class CreateInOutEvents(beam.PTransform, InOutEventsBase):
     def _create_in_out_events(self, records):
         records = sorted(records, key=lambda x: x.timestamp)
         ssvid, vessel_id, seg_id = records[0].identifier
-        # identity = (ssvid, vessel_id)
         rcd = None
         last_state = None
         active_port_rcd = None
         last_timestamp = None
         for rcd in records:
-            # s2id = rcd.location.S2CellId(cmn.VISITS_S2_SCALE).to_token()
-            # port, dist = self._anchorage_distance(
-            #     rcd.location, anchorage_map.get(s2id, [])
-            # )
-            # s2_id =
             is_in_port = self._is_in_port(last_state, rcd.port_dist)
             active_port_rcd = rcd if is_in_port else active_port_rcd
             is_stopped = self._is_stopped(last_state, rcd.speed)

--- a/pipe_anchorages/transforms/create_in_out_events.py
+++ b/pipe_anchorages/transforms/create_in_out_events.py
@@ -140,7 +140,6 @@ class CreateInOutEvents(beam.PTransform, InOutEventsBase):
         active_port = None
         last_timestamp = None
         for rcd in records:
-
             s2id = rcd.location.S2CellId(cmn.VISITS_S2_SCALE).to_token()
             port, dist = self._anchorage_distance(
                 rcd.location, anchorage_map.get(s2id, [])
@@ -153,6 +152,7 @@ class CreateInOutEvents(beam.PTransform, InOutEventsBase):
             if last_timestamp is not None:
                 if (
                     last_state in self.in_port_states
+                    and rcd.is_possible_gap_end
                     and rcd.timestamp - last_timestamp >= self.min_gap
                 ):
                     yield self._build_event(

--- a/pipe_anchorages/transforms/create_port_visits.py
+++ b/pipe_anchorages/transforms/create_port_visits.py
@@ -11,7 +11,6 @@ from pipe_anchorages.objects.port_visit import PortVisit
 
 
 class CreatePortVisits(beam.PTransform):
-
     EVENT_TYPES = [
         "PORT_ENTRY",
         # The order of PORT_GAP_XXX is somewhat arbitrary, but it
@@ -58,7 +57,7 @@ class CreatePortVisits(beam.PTransform):
         return events
 
     def create_visit(self, id_, visit_events):
-        ssvid, vessel_id, seg_id = id_
+        ssvid, vessel_id = id_
         raw_visit_id = "{}-{}-{}-{}".format(
             vessel_id,
             visit_events[0].timestamp.isoformat(),
@@ -106,7 +105,7 @@ class CreatePortVisits(beam.PTransform):
         grouping_id, events = tagged_events
         if not len(events):
             return
-        id_ = events[0].ssvid, events[0].vessel_id, events[0].seg_id
+        id_ = events[0].ssvid, events[0].vessel_id
         # Sort events by timestamp, and also so that enter, stop, start,
         # exit are in the correct order.
         tagged = [(x.timestamp, self.TYPE_ORDER[x.event_type], x) for x in events]

--- a/pipe_anchorages/transforms/smart_thin_records.py
+++ b/pipe_anchorages/transforms/smart_thin_records.py
@@ -11,9 +11,9 @@ from ..common import LatLon
 from .create_in_out_events import InOutEventsBase
 
 
-class VisitLocationRecord:
+class VisitLocationRecord(NamedTuple):
     identifier: str
-    timestamp: datetime
+    timestamp: datetime.datetime
     location: LatLon
     speed: float
     is_possible_gap_end: bool

--- a/pipe_anchorages/transforms/smart_thin_records.py
+++ b/pipe_anchorages/transforms/smart_thin_records.py
@@ -62,13 +62,6 @@ class SmartThinRecords(beam.PTransform, InOutEventsBase):
         last_state = None
         active_port = None
         for i, rcd in enumerate(records):
-            # rcd = VisitLocationRecord(
-            #     identifier=rcd.identifier,
-            #     timestamp=rcd.timestamp,
-            #     location=rcd.location,
-            #     speed=rcd.speed,
-            #     is_possible_gap_end=False,
-            # )
             s2id = rcd.location.S2CellId(cmn.VISITS_S2_SCALE).to_token()
             port, dist = self._anchorage_distance(
                 rcd.location, anchorage_map.get(s2id, [])


### PR DESCRIPTION
This builds on the changes in #102 by also caching port location information in the thinned messages so that this does not need to be recalculated each time. The hope is that this will improve performance of port_visits.

