### PR TITLE
Fixes cruising vessels near port detected as port visits

### DIFF
--- a/pipe_anchorages/port_visits_pipeline.py
+++ b/pipe_anchorages/port_visits_pipeline.py
@@ -1,22 +1,25 @@
-from apache_beam import io
 from apache_beam.options.pipeline_options import StandardOptions, GoogleCloudOptions
 from apache_beam.runners import PipelineState
+import datetime
+import logging
 
+import apache_beam as beam
+import pytz
+from apache_beam import Map
+from apache_beam.options.pipeline_options import (GoogleCloudOptions,
+                                                  StandardOptions)
+from apache_beam.runners import PipelineState
 from pipe_anchorages import common as cmn
 from pipe_anchorages.objects.namedtuples import _datetime_to_s
 from pipe_anchorages.options.port_visits_options import PortVisitsOptions
-from pipe_anchorages.records import VesselLocationRecord
 from pipe_anchorages.schema.port_visit import build as build_visit_schema
 from pipe_anchorages.transforms.create_in_out_events import CreateInOutEvents
 from pipe_anchorages.transforms.create_port_visits import CreatePortVisits
-from pipe_anchorages.transforms.create_tagged_anchorages import CreateTaggedAnchorages
+from pipe_anchorages.transforms.create_tagged_anchorages import \
+    CreateTaggedAnchorages
 from pipe_anchorages.transforms.sink import VisitsSink
+from pipe_anchorages.transforms.smart_thin_records import VisitLocationRecord
 from pipe_anchorages.transforms.source import QuerySource
-
-import apache_beam as beam
-import datetime
-import logging
-import pytz
 
 
 def create_queries(args, start_date, end_date):
@@ -48,7 +51,12 @@ def create_queries(args, start_date, end_date):
         start_window = end_window + datetime.timedelta(days=1)
 
 
-anchorage_query = lambda table: f"SELECT lat as anchor_lat, lon as anchor_lon, s2id as anchor_id, label FROM `{table}`"
+anchorage_query = (
+    lambda table: f"SELECT lat as anchor_lat, lon as anchor_lon, s2id as anchor_id, label FROM `{table}`"
+)
+
+
+# TODO:
 
 
 def from_msg(x):
@@ -61,7 +69,7 @@ def from_msg(x):
     vessel_id = x_new.pop("vessel_id")
     ident = (ssvid, vessel_id, seg_id)
     loc = cmn.LatLon(x_new.pop("lat"), x_new.pop("lon"))
-    return vessel_id, VesselLocationRecord(identifier=ident, location=loc, **x_new)
+    return vessel_id, VisitLocationRecord(identifier=ident, location=loc, **x_new)
 
 
 def event_to_msg(x):
@@ -88,7 +96,6 @@ def drop_new_fields(x):
 strdate_to_utcdate = lambda strdate: datetime.datetime.strptime(strdate, "%Y-%m-%d").replace(tzinfo=pytz.utc)
 
 def run(options):
-
     visit_args = options.view_as(PortVisitsOptions)
     cloud_args = options.view_as(GoogleCloudOptions)
 
@@ -101,23 +108,20 @@ def run(options):
 
     anchorages = (
         p
-        | "ReadAnchorages" >> QuerySource(anchorage_query(visit_args.anchorage_table), cloud_args)
+        | "ReadAnchorages"
+        >> QuerySource(anchorage_query(visit_args.anchorage_table), cloud_args)
         | CreateTaggedAnchorages()
     )
 
     queries = create_queries(visit_args, start_date, end_date)
 
     sources = [
-        (
-            p | f"ReadThinnedMessagesJoinedVesselId_{i}" >> QuerySource(query, cloud_args)
-        ) for (i, query) in enumerate(queries)
+        (p | f"ReadThinnedMessagesJoinedVesselId_{i}" >> QuerySource(query, cloud_args))
+        for (i, query) in enumerate(queries)
     ]
 
     sink = VisitsSink(
-        visit_args.output_table,
-        build_visit_schema(),
-        visit_args,
-        cloud_args
+        visit_args.output_table, build_visit_schema(), visit_args, cloud_args
     )
 
     (
@@ -158,5 +162,3 @@ def run(options):
 
     logging.info("returning with result.state=%s" % result.state)
     return 0 if result.state in success_states else 1
-
-

--- a/pipe_anchorages/port_visits_pipeline.py
+++ b/pipe_anchorages/port_visits_pipeline.py
@@ -2,6 +2,7 @@ from apache_beam.options.pipeline_options import StandardOptions, GoogleCloudOpt
 from apache_beam.runners import PipelineState
 import datetime
 import logging
+import math
 
 import apache_beam as beam
 import pytz
@@ -56,9 +57,6 @@ anchorage_query = (
 )
 
 
-# TODO:
-
-
 def from_msg(x):
     x_new = x.copy()
     x_new["timestamp"] = datetime.datetime.utcfromtimestamp(x_new["timestamp"]).replace(
@@ -69,7 +67,12 @@ def from_msg(x):
     vessel_id = x_new.pop("vessel_id")
     ident = (ssvid, vessel_id, seg_id)
     loc = cmn.LatLon(x_new.pop("lat"), x_new.pop("lon"))
-    return vessel_id, VisitLocationRecord(identifier=ident, location=loc, **x_new)
+    port_dist = x_new.pop('port_dist')
+    if port_dist is None:
+        port_dist = math.inf
+    return vessel_id, VisitLocationRecord(
+        identifier=ident, location=loc, port_dist=port_dist, **x_new
+    )
 
 
 def event_to_msg(x):

--- a/pipe_anchorages/schema/message_schema.py
+++ b/pipe_anchorages/schema/message_schema.py
@@ -26,7 +26,7 @@ message_schema = {
             "type": "FLOAT",
         },
         {
-            "description": "Could this message could this message be a gap end.",
+            "description": "Could this message be a gap end.",
             "mode": "NULLABLE",
             "name": "is_possible_gap_end",
             "type": "BOOL",

--- a/pipe_anchorages/schema/message_schema.py
+++ b/pipe_anchorages/schema/message_schema.py
@@ -26,10 +26,10 @@ message_schema = {
             "type": "FLOAT",
         },
         {
-            "description": "The destination included in the message.",
+            "description": "Could this message could this message be a gap end.",
             "mode": "NULLABLE",
-            "name": "destination",
-            "type": "STRING",
+            "name": "is_possible_gap_end",
+            "type": "BOOL",
         },
     ]
 }

--- a/pipe_anchorages/schema/message_schema.py
+++ b/pipe_anchorages/schema/message_schema.py
@@ -31,5 +31,29 @@ message_schema = {
             "name": "is_possible_gap_end",
             "type": "BOOL",
         },
+        {
+            "description": "If we are near an anchorage, what is it's S2 ID.",
+            "mode": "NULLABLE",
+            "name": "port_s2id",
+            "type": "STRING",
+        },
+        {
+            "description": "If we are near an anchorage, how far away is it.",
+            "mode": "NULLABLE",
+            "name": "port_dist",
+            "type": "FLOAT",
+        },
+        {
+            "description": "If we are near an anchorage, what is its mean longitude.",
+            "mode": "NULLABLE",
+            "name": "port_lon",
+            "type": "FLOAT",
+        },
+        {
+            "description": "If we are near an anchorage, what is its mean latitude.",
+            "mode": "NULLABLE",
+            "name": "port_lat",
+            "type": "FLOAT",
+        },
     ]
 }

--- a/pipe_anchorages/transforms/create_in_out_events.py
+++ b/pipe_anchorages/transforms/create_in_out_events.py
@@ -115,7 +115,7 @@ class CreateInOutEvents(beam.PTransform, InOutEventsBase):
             last_timestamp=last_timestamp,
         )
 
-    def _yield_gap_beg(self, gap_end_rcd, last_timestamp, last_state, active_port):
+    def _yield_gap_beg(self, gap_end_rcd, last_timestamp, active_port):
         evt_timestamp = last_timestamp + self.min_gap
         assert evt_timestamp <= gap_end_rcd.timestamp
         rcd = PseudoRcd(
@@ -151,7 +151,7 @@ class CreateInOutEvents(beam.PTransform, InOutEventsBase):
                         active_port, rcd, self.EVT_GAP_END, last_timestamp
                     )
                     yield from self._yield_gap_beg(
-                        rcd, last_timestamp, last_state, active_port
+                        rcd, last_timestamp, active_port
                     )
 
             for event_type in self.transition_map[(last_state, state)]:

--- a/pipe_anchorages/transforms/create_port_visits.py
+++ b/pipe_anchorages/transforms/create_port_visits.py
@@ -56,7 +56,7 @@ class CreatePortVisits(beam.PTransform):
         return events
 
     def create_visit(self, id_, visit_events):
-        ssvid, vessel_id, seg_id = id_
+        ssvid, vessel_id = id_
         raw_visit_id = "{}-{}-{}-{}".format(
             vessel_id,
             visit_events[0].timestamp.isoformat(),
@@ -104,7 +104,7 @@ class CreatePortVisits(beam.PTransform):
         grouping_id, events = tagged_events
         if not len(events):
             return
-        id_ = events[0].ssvid, events[0].vessel_id, events[0].seg_id
+        id_ = events[0].ssvid, events[0].vessel_id
         # Sort events by timestamp, and also so that enter, stop, start,
         # exit are in the correct order.
         tagged = [(x.timestamp, self.TYPE_ORDER[x.event_type], x) for x in events]

--- a/pipe_anchorages/transforms/smart_thin_records.py
+++ b/pipe_anchorages/transforms/smart_thin_records.py
@@ -1,8 +1,9 @@
 from __future__ import absolute_import, division, print_function
 
 import datetime
+import math
 from datetime import timedelta
-from typing import NamedTuple
+from typing import NamedTuple, Optional
 
 import apache_beam as beam
 from pipe_anchorages import common as cmn
@@ -17,6 +18,10 @@ class VisitLocationRecord(NamedTuple):
     location: LatLon
     speed: float
     is_possible_gap_end: bool
+    port_s2id: Optional[str]
+    port_dist: Optional[float]
+    port_lon: Optional[float]
+    port_lat: Optional[float]
 
 
 class SmartThinRecords(beam.PTransform, InOutEventsBase):
@@ -57,17 +62,23 @@ class SmartThinRecords(beam.PTransform, InOutEventsBase):
         last_state = None
         active_port = None
         for i, rcd in enumerate(records):
+            s2id = rcd.location.S2CellId(cmn.VISITS_S2_SCALE).to_token()
+            port, dist = self._anchorage_distance(
+                rcd.location, anchorage_map.get(s2id, [])
+            )
+
             rcd = VisitLocationRecord(
                 identifier=rcd.identifier,
                 timestamp=rcd.timestamp,
                 location=rcd.location,
                 speed=rcd.speed,
                 is_possible_gap_end=False,
+                port_s2id=port.s2id if port else None,
+                port_dist=dist if not math.isinf(dist) else None,
+                port_lon=port.mean_location.lon if port else None,
+                port_lat=port.mean_location.lat if port else None,
             )
-            s2id = rcd.location.S2CellId(cmn.VISITS_S2_SCALE).to_token()
-            port, dist = self._anchorage_distance(
-                rcd.location, anchorage_map.get(s2id, [])
-            )
+
             is_in_port = self._is_in_port(last_state, dist)
             active_port = port if is_in_port else active_port
             is_stopped = self._is_stopped(last_state, rcd.speed)


### PR DESCRIPTION
Relates to https://globalfishingwatch.atlassian.net/browse/PIPELINE-1845

This is a squash rebase of the following individual commits for easier merging:

* Initial sketch of tagging thinned messages to reduce generating extra gaps in port
* Revert formatting changes to thin_port_visits_pipeline to minimize PR footprint
* Needed to incorporate possible_gap_end into gap_start as well as end, which means not using it for last state. Also fix bug where we forgot to inherit from NamedTuple
* Set the first message of the day to be a possible gap; be more careful to only emit one item for each message
* Improve labelling of events inside port visits, often which had incorrect seg_id. Also clean up section that wasn't causing an issue, but was confusing and would likely lead to some bugs later