### PR TITLE
Add final gap

### DIFF
--- a/Anchorages with VMS notes
+++ b/Anchorages with VMS notes
@@ -1,0 +1,12 @@
+* Efficiency improvements to avoid hot keys
+* Combined vs separate
+    - If combined break out VMS systems
+    - separate is more extendable, but in some ways makes less sense.
+* Normalize vs presence hours?
+
+* raster of vessel density
+
+* 
+    - One other researcher for knowledge transfer
+    - Engineering support
+    - Analysis support

--- a/pipe_anchorages/options/port_visits_options.py
+++ b/pipe_anchorages/options/port_visits_options.py
@@ -23,9 +23,6 @@ class PortVisitsOptions(PipelineOptions):
             help="Name of table mapping vessel_id to seg_id (BQ). "
             "Should have one vessel_id per seg_id, e.g. the `segment_info` table.",
         )
-        required.add_argument(
-            "--anchorage_table", help="Name of of anchorages table (BQ)"
-        )
         optional.add_argument(
             "--config", default="anchorage_cfg.yaml", help="Path to configuration file"
         )
@@ -34,7 +31,6 @@ class PortVisitsOptions(PipelineOptions):
             required=True,
             help="Output table (BQ) to write results to.",
         )
-
         required.add_argument(
             "--start_date", required=True, help="First date (inclusive) to generate visits"
         )

--- a/pipe_anchorages/transforms/create_in_out_events.py
+++ b/pipe_anchorages/transforms/create_in_out_events.py
@@ -165,7 +165,8 @@ class CreateInOutEvents(beam.PTransform, InOutEventsBase):
             and rcd.is_possible_gap_end
             and self.last_possible_timestamp - last_timestamp >= self.min_gap
         ):
-            yield from self._yield_gap_beg(rcd, last_timestamp, active_port_rcd)
+            psuedo_rcd = rcd._replace(timestamp=self.last_possible_timestamp)
+            yield from self._yield_gap_beg(psuedo_rcd, last_timestamp, active_port_rcd)
 
     def create_in_out_events(self, grouped_records):
         identity, records = grouped_records

--- a/pipe_anchorages/transforms/create_in_out_events.py
+++ b/pipe_anchorages/transforms/create_in_out_events.py
@@ -82,7 +82,6 @@ class InOutEventsBase:
 class CreateInOutEvents(beam.PTransform, InOutEventsBase):
     def __init__(
         self,
-        anchorages,
         anchorage_entry_dist,
         anchorage_exit_dist,
         stopped_begin_speed,
@@ -90,13 +89,15 @@ class CreateInOutEvents(beam.PTransform, InOutEventsBase):
         min_gap_minutes,
         end_date,
     ):
-        self.anchorages = anchorages
         self.anchorage_entry_dist = anchorage_entry_dist
         self.anchorage_exit_dist = anchorage_exit_dist
         self.stopped_begin_speed = stopped_begin_speed
         self.stopped_end_speed = stopped_end_speed
         self.min_gap = timedelta(minutes=min_gap_minutes)
         self.end_date = end_date
+        self.last_possible_timestamp = (
+            end_date + timedelta(days=1) - timedelta(microseconds=1)
+        )
         assert self.min_gap < timedelta(
             days=1
         ), "min gap must be under one day in current implementation"
@@ -159,6 +160,12 @@ class CreateInOutEvents(beam.PTransform, InOutEventsBase):
 
             last_timestamp = rcd.timestamp
             last_state = state
+        if (
+            last_state in self.in_port_states
+            and rcd.is_possible_gap_end
+            and self.last_possible_timestamp - last_timestamp >= self.min_gap
+        ):
+            yield from self._yield_gap_beg(rcd, last_timestamp, active_port_rcd)
 
     def create_in_out_events(self, grouped_records):
         identity, records = grouped_records

--- a/pipe_anchorages/transforms/sink.py
+++ b/pipe_anchorages/transforms/sink.py
@@ -1,17 +1,15 @@
-from apache_beam import Map, PTransform, io
-from apache_beam.transforms.window import TimestampedValue
-
-from datetime import timedelta
-
-from google.cloud import bigquery
-
-from pipe_anchorages.schema.message_schema import message_schema
-from pipe_anchorages.schema.named_anchorage import build as build_named_anchorage_schema
-from pipe_anchorages.utils.ver import get_pipe_ver
-from pipe_anchorages.objects.namedtuples import epoch
-
 import datetime as dt
 import logging
+from datetime import timedelta
+
+from apache_beam import Map, PTransform, io
+from apache_beam.transforms.window import TimestampedValue
+from google.cloud import bigquery
+from pipe_anchorages.objects.namedtuples import epoch
+from pipe_anchorages.schema.message_schema import message_schema
+from pipe_anchorages.schema.named_anchorage import \
+    build as build_named_anchorage_schema
+from pipe_anchorages.utils.ver import get_pipe_ver
 
 cloud_to_labels = lambda ll: {x.split('=')[0]:x.split('=')[1] for x in ll}
 
@@ -278,7 +276,6 @@ Creates the visits to port table.
 * https://github.com/GlobalFishingWatch/anchorages_pipeline
 * Sources: {self.args.thinned_message_table}
 * Vessel id to join identification: {self.args.vessel_id_table}
-* Anchorage table: {self.args.anchorage_table}
 * Configuration file: {self.args.config}
 * Skip bad segments: {"Yes" if self.args.bad_segs else "No"}
 * Segments more than this distance apart will not be joined when creating visits: {self.args.max_inter_seg_dist_nm}
@@ -315,4 +312,3 @@ Creates the visits to port table.
                 },
             )
         )
-

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import find_packages, setup
 
 setup(
     name="pipe_anchorages",
-    version="4.2.4",
+    version="4.3.1",
     packages=find_packages(exclude=["test*.*", "tests"]),
     package_data={
         "": ["data/port_lists/*.csv", "data/EEZ/*"],


### PR DESCRIPTION
This PR does two things:

1. Add a final port-gap-begin when appropriate.
    - Effects `create_in_out_events.py` only.
    - Current version will not generate a port gap begin until the first point after the port gap.
    - This is the primary purpose of this PR.
3. Clean up 
    - We were still loading the anchorages data even thought it isn't used in this pipeline. Removed.
    - Use only a single query instead of breaking into pieces.
    - Minor formatting and naming improvements.