### PR TITLE
Dependencies reported error: fix them. Increments to the latest stable pyyaml version 6.0.2

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -38,6 +38,7 @@ jobs:
       - name: Install dependencies
         run: |
           pip install --upgrade pip
+          apt-get install libgeos-dev
           pip install -r requirements/test.txt
           pip install -e .
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -25,6 +25,8 @@ jobs:
 
   tests:
     runs-on: ubuntu-latest
+    env:
+      GDAL_VERSION: "3.6.2"
     strategy:
       matrix:
         python-version: ["3.8", "3.9", "3.10", "3.11", "3.12"]
@@ -38,7 +40,6 @@ jobs:
       - name: Install dependencies
         run: |
           pip install --upgrade pip
-          export GDAL_VERSION="3.6.2"
           sudo apt-get install libgeos-dev
           pip install -r requirements/test.txt
           pip install -e .

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -38,6 +38,7 @@ jobs:
       - name: Install dependencies
         run: |
           pip install --upgrade pip
+          export GDAL_VERSION="3.6.2"
           sudo apt-get install libgeos-dev
           pip install -r requirements/test.txt
           pip install -e .

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -40,7 +40,7 @@ jobs:
       - name: Install dependencies
         run: |
           pip install --upgrade pip
-          sudo apt-get install libgeos-dev
+          sudo apt-get install libgdal-dev
           pip install -r requirements/test.txt
           pip install -e .
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -38,7 +38,7 @@ jobs:
       - name: Install dependencies
         run: |
           pip install --upgrade pip
-          apt-get install libgeos-dev
+          sudo apt-get install libgeos-dev
           pip install -r requirements/test.txt
           pip install -e .
 

--- a/Dockerfile-worker
+++ b/Dockerfile-worker
@@ -1,4 +1,4 @@
-FROM apache/beam_python3.8_sdk:2.49.0
+FROM apache/beam_python3.8_sdk:2.59.0
 
 # Setup local application dependencies
 COPY ./requirements-worker.txt ./

--- a/requirements-scheduler.txt
+++ b/requirements-scheduler.txt
@@ -1,4 +1,4 @@
-apache-beam[gcp]==2.49.0
+apache-beam[gcp]==2.59.0
 pytest==7.2.2
 jinja2-cli==0.8.2
 pyyaml==6.0.2

--- a/requirements-scheduler.txt
+++ b/requirements-scheduler.txt
@@ -1,4 +1,4 @@
 apache-beam[gcp]==2.49.0
 pytest==7.2.2
 jinja2-cli==0.8.2
-pyyaml==5.4.1
+pyyaml==6.0.2

--- a/requirements-worker.txt
+++ b/requirements-worker.txt
@@ -1,4 +1,4 @@
-pyyaml==5.4.1
+pyyaml==6.0.2
 Fiona==1.8.20
 Shapely==1.7.1
 s2sphere==0.2.5

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ setuptools.setup(
         "Operating System :: OS Independent",
     ],
     install_requires=[
-        "apache-beam[gcp]~=2.49.0",
+        "apache-beam[gcp]~=2.59.0",
         "jinja2-cli~=0.8.0",
         "pyyaml~=6.0.0",
         "Fiona~=1.8.0",

--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,7 @@ setuptools.setup(
         "jinja2<4",
         "pyyaml<7",
         "Fiona<2",
-        "Shapely<2",
+        "Shapely==1.7.1",
         "s2sphere<1",
         "Unidecode<2",
     ],

--- a/setup.py
+++ b/setup.py
@@ -24,13 +24,13 @@ setuptools.setup(
         "Operating System :: OS Independent",
     ],
     install_requires=[
-        "apache-beam[gcp]<3",
-        "jinja2<4",
-        "pyyaml<7",
-        "Fiona<2",
-        "Shapely==1.7.1",
-        "s2sphere<1",
-        "Unidecode<2",
+        "apache-beam[gcp]~=2.49.0",
+        "jinja2-cli~=0.8.0",
+        "pyyaml~=6.0.0",
+        "Fiona~=1.8.0",
+        "Shapely~=1.7.0",
+        "s2sphere~=0.2.0",
+        "Unidecode~=1.2.0",
     ],
     entry_points={
         "console_scripts": [

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ setuptools.setup(
     install_requires=[
         "apache-beam[gcp]<3",
         "jinja2<4",
-        "pyyaml<6",
+        "pyyaml<7",
         "Fiona<2",
         "Shapely<2",
         "s2sphere<1",

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ setuptools.setup(
         "apache-beam[gcp]~=2.59.0",
         "jinja2-cli~=0.8.0",
         "pyyaml~=6.0.0",
-        "Fiona~=1.8.0",
+        "Fiona<2",
         "Shapely~=1.7.0",
         "s2sphere~=0.2.0",
         "Unidecode~=1.2.0",


### PR DESCRIPTION
Issues when installing `pyyaml==5.4.1 not compatible with cython3` Reported: https://github.com/yaml/pyyaml/issues/724 Increment to `6.0.2` stable version.
Fixing error in the GitHubAction when trying to install `Shaply` `OSError: Could not find library geos_c or load any of its variants ['libgeos_c.so.1', 'libgeos_c.so']`
Increments tne Beam version to avoid having a deprecated one.