### PR TITLE
Deletes the content of the voyages confidence tables when preparing the table

### DIFF
--- a/pipe_anchorages/confidence_voyages.py
+++ b/pipe_anchorages/confidence_voyages.py
@@ -19,6 +19,11 @@ confidence_meaning = {
     "4": "port entry and exit with stop and/or gap",
 }
 
+DROP_VOYAGES_QUERY = """
+DELETE FROM `{table_id}`
+WHERE date({partitioning_field}) >= '1970-01-01' or {partitioning_field} is null
+"""
+
 
 def run(arguments):
     parser = argparse.ArgumentParser(description="Generates the confidence voyages tables.")
@@ -86,6 +91,12 @@ def run(arguments):
         partitioning_field="trip_start",
     )
     bq_helper.ensure_table_exists(table)
+    bq_helper.run_query(
+        query=DROP_VOYAGES_QUERY.format(
+            table_id=table.table_id,
+            partitioning_field=table.partitioning_field,
+        )
+    )
     bq_helper.update_table(table)
 
     # Apply template


### PR DESCRIPTION
This will deletes the content inside the `voyages_c2/3/4`.
Port visit does not need it because the visitSink is Write_Truncate disposition, so every run it generates the content from zero.


The Condition in the query was retrieved from: https://github.com/GlobalFishingWatch/anchorages_pipeline/commit/427af2d16c7a38c5263b1f47d19a901315c41246#diff-09bd8d2ce8626b4650717d0181227ba26570acf51eff5f39c66a723d2e71cb47L88

I tested locally, run the query several times ensuring that everytime it runs there is no content inside it.
First run `3:55pm`:
![Screenshot from 2025-06-30 15-55-53](https://github.com/user-attachments/assets/0286b9f4-3633-4769-b5f5-8f656b9559a1)

--
Second run check empty content `3:56pm`:
![Screenshot from 2025-06-30 15-57-53](https://github.com/user-attachments/assets/98af086f-4eb3-447b-a5a3-290689f131c4)

--
Second run `3:57pm`
![Screenshot from 2025-06-30 15-58-18](https://github.com/user-attachments/assets/9784ff60-5902-4c5a-9297-8105fe475af2)
