### PR TITLE
Fix/pipeline 1465 port visit start location

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,6 +8,20 @@ Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to
 
 ## [Unreleased]
 
+### Fixed
+
+* [PIPELINE-1465](https://globalfishingwatch.atlassian.net/browse/PIPELINE-1465): Fixes
+  `PORT_GAP_BEGIN` events being tagged with the post-gap anchorage instead of
+  the pre-gap one. When a vessel went silent at one anchorage and reappeared at
+  another, port visits whose first event was `PORT_GAP_BEGIN` were assigned the
+  resuming anchorage's location while keeping a `start_timestamp` of
+  `last_in_port_ts + min_gap` -- describing the visit at a location the vessel
+  had not yet reached. The gap-pair emission now snapshots `active_port_rcd`
+  before the per-iteration update so `PORT_GAP_BEGIN` is anchored to where the
+  vessel was last seen, while `PORT_GAP_END` continues to reflect where it
+  reappeared. Affects confidence-2 and confidence-3 visits that begin with
+  `PORT_GAP_BEGIN`.
+
 ## v3.4.0 - 2023-08-02
 
 ### Added

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -8,6 +8,8 @@ Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to
 
 ## [Unreleased]
 
+## v4.6.5 - 2026-05-04
+
 ### Fixed
 
 * [PIPELINE-1465](https://globalfishingwatch.atlassian.net/browse/PIPELINE-1465): Fixes

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,7 +15,7 @@ namespaces = false
 
 [project]
 name = "pipe-anchorages"
-version = "4.6.4"
+version = "4.6.5"
 description = "Tools for finding anchorages and associated port-visit events."
 readme = "README.md"
 license = { text = "Apache-2.0" }

--- a/src/pipe_anchorages/transforms/create_in_out_events.py
+++ b/src/pipe_anchorages/transforms/create_in_out_events.py
@@ -134,6 +134,10 @@ class CreateInOutEvents(beam.PTransform, InOutEventsBase):
         last_timestamp = None
         for rcd in records:
             is_in_port = self._is_in_port(last_state, rcd.port_dist)
+            # The pre-update active_port_rcd anchors PORT_GAP_BEGIN to where
+            # the vessel was last seen in port. The post-update one anchors
+            # PORT_GAP_END to where the vessel reappeared.
+            prev_active_port_rcd = active_port_rcd
             active_port_rcd = rcd if is_in_port else active_port_rcd
             is_stopped = self._is_stopped(last_state, rcd.speed)
             state = self._compute_state(is_in_port, is_stopped)
@@ -145,7 +149,7 @@ class CreateInOutEvents(beam.PTransform, InOutEventsBase):
                     and rcd.timestamp - last_timestamp >= self.min_gap
                 ):
                     yield self._build_event(active_port_rcd, rcd, self.EVT_GAP_END, last_timestamp)
-                    yield from self._yield_gap_beg(rcd, last_timestamp, active_port_rcd)
+                    yield from self._yield_gap_beg(rcd, last_timestamp, prev_active_port_rcd)
 
             for event_type in self.transition_map[(last_state, state)]:
                 yield self._build_event(active_port_rcd, rcd, event_type, last_timestamp)

--- a/src/pipe_anchorages/transforms/create_in_out_events.py
+++ b/src/pipe_anchorages/transforms/create_in_out_events.py
@@ -131,13 +131,10 @@ class CreateInOutEvents(beam.PTransform, InOutEventsBase):
         rcd = None
         last_state = None
         active_port_rcd = None
+        last_active_port_rcd = None
         last_timestamp = None
         for rcd in records:
             is_in_port = self._is_in_port(last_state, rcd.port_dist)
-            # The pre-update active_port_rcd anchors PORT_GAP_BEGIN to where
-            # the vessel was last seen in port. The post-update one anchors
-            # PORT_GAP_END to where the vessel reappeared.
-            prev_active_port_rcd = active_port_rcd
             active_port_rcd = rcd if is_in_port else active_port_rcd
             is_stopped = self._is_stopped(last_state, rcd.speed)
             state = self._compute_state(is_in_port, is_stopped)
@@ -148,14 +145,18 @@ class CreateInOutEvents(beam.PTransform, InOutEventsBase):
                     and rcd.is_possible_gap_end
                     and rcd.timestamp - last_timestamp >= self.min_gap
                 ):
+                    # PORT_GAP_END is anchored at the resuming record (active_port_rcd),
+                    # while PORT_GAP_BEGIN is anchored at the prior in-port record
+                    # (last_active_port_rcd) to match its synthetic timestamp.
                     yield self._build_event(active_port_rcd, rcd, self.EVT_GAP_END, last_timestamp)
-                    yield from self._yield_gap_beg(rcd, last_timestamp, prev_active_port_rcd)
+                    yield from self._yield_gap_beg(rcd, last_timestamp, last_active_port_rcd)
 
             for event_type in self.transition_map[(last_state, state)]:
                 yield self._build_event(active_port_rcd, rcd, event_type, last_timestamp)
 
             last_timestamp = rcd.timestamp
             last_state = state
+            last_active_port_rcd = active_port_rcd
         if (
             # Trigger gap ends for gaps that started but we haven't reached their end
             last_state in self.in_port_states

--- a/tests/test_create_in_out_events.py
+++ b/tests/test_create_in_out_events.py
@@ -1,0 +1,96 @@
+import datetime
+
+import pytz
+
+from pipe_anchorages.common import LatLon
+from pipe_anchorages.transforms.create_in_out_events import CreateInOutEvents
+from pipe_anchorages.transforms.smart_thin_records import VisitLocationRecord
+
+
+def _utc(year, month, day, hour=0, minute=0):
+    return datetime.datetime(year, month, day, hour, minute, tzinfo=pytz.utc)
+
+
+def _make_in_out_events(end_time):
+    return CreateInOutEvents(
+        anchorage_entry_dist=3.0,
+        anchorage_exit_dist=4.0,
+        stopped_begin_speed=0.2,
+        stopped_end_speed=0.5,
+        min_gap_minutes=240.0,
+        end_time=end_time,
+    )
+
+
+class TestGapBeginAnchorageOnSilentTransit:
+    """When a vessel goes silent at one anchorage and reappears at another,
+    PORT_GAP_BEGIN must be located at the *pre-gap* anchorage.
+
+    `start_timestamp` for a visit that begins with PORT_GAP_BEGIN is
+    `T_lastInPort + min_gap` -- a moment at which the only thing the data
+    tells us about the vessel's location is the last in-port observation.
+    Tagging that synthetic timestamp with the post-gap anchorage describes
+    the visit as being somewhere the vessel had not yet reached.
+    """
+
+    identifier = ("ssvid", "vessel_id", "seg_id")
+    # t1 sits close enough to end-of-day that the trailing-gap branch in
+    # `_create_in_out_events` does not fire (last_possible_timestamp - t1 < min_gap),
+    # leaving us with only the inline gap pair to assert against.
+    t0 = _utc(2024, 1, 2, 15, 0)
+    t1 = _utc(2024, 1, 2, 21, 0)  # 6h after t0, > min_gap
+    end_time = _utc(2024, 1, 2)
+
+    rcd_at_a = VisitLocationRecord(
+        identifier=identifier,
+        timestamp=t0,
+        location=LatLon(45.0, -100.0),
+        speed=0.0,
+        is_possible_gap_end=False,
+        port_s2id="anchA",
+        port_dist=1.0,
+        port_lat=45.0,
+        port_lon=-100.0,
+    )
+    rcd_at_b = VisitLocationRecord(
+        identifier=identifier,
+        timestamp=t1,
+        location=LatLon(46.0, -101.0),
+        speed=0.0,
+        is_possible_gap_end=True,
+        port_s2id="anchB",
+        port_dist=1.0,
+        port_lat=46.0,
+        port_lon=-101.0,
+    )
+
+    def _events(self):
+        in_out = _make_in_out_events(end_time=self.end_time)
+        _, events = in_out.create_in_out_events(
+            (self.identifier, [self.rcd_at_a, self.rcd_at_b])
+        )
+        return events
+
+    def test_gap_pair_is_emitted_with_no_other_events(self):
+        events = self._events()
+        types = [e.event_type for e in events]
+        assert types == ["PORT_GAP_END", "PORT_GAP_BEGIN"]
+
+    def test_gap_end_anchored_to_resuming_record(self):
+        gap_end = next(e for e in self._events() if e.event_type == "PORT_GAP_END")
+        assert gap_end.timestamp == self.t1
+        assert gap_end.anchorage_id == "anchB"
+        assert gap_end.lat == 46.0
+        assert gap_end.lon == -101.0
+
+    def test_gap_begin_timestamp_is_last_in_port_plus_min_gap(self):
+        gap_begin = next(
+            e for e in self._events() if e.event_type == "PORT_GAP_BEGIN"
+        )
+        assert gap_begin.timestamp == self.t0 + datetime.timedelta(minutes=240)
+
+    def test_gap_begin_anchorage_matches_pre_gap_position(self):
+        gap_begin = next(e for e in self._events() if e.event_type == "PORT_GAP_BEGIN")
+        assert gap_begin.anchorage_id == "anchA"
+        assert gap_begin.lat == 45.0
+        assert gap_begin.lon == -100.0


### PR DESCRIPTION
DRAFT - DO NOT MERGE

More information below. I'd like to first run this on a) the "staging" dataset; and b) VMS data.

---

Snapshot active_port_rcd before the per-iteration update so the synthetic PORT_GAP_BEGIN event is anchored to where the vessel was last seen, while PORT_GAP_END continues to reflect where it reappeared. Previously both events shared the post-update value, which described the gap's start at a location the vessel had not yet reached when its start_timestamp (last_in_port_ts + min_gap) elapsed. Affects confidence-2 and confidence-3 port visits that begin with PORT_GAP_BEGIN.

Adds a regression test covering the silent inter-anchorage transit scenario.

PIPELINE-1465